### PR TITLE
This lambda is now running in a step function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,55 @@
 # TDR Redacted Files
 
-This lambda is passed a list of file paths and if there is a file matching the redacted file pattern, either finds the
+This lambda is passed an object with an S3 key and bucket.
+It gets that object from S3 which returns a json object.
+The results key in that json is a list of file paths and if there is a file matching the redacted file pattern, either finds the
 original file or returns an error.
 If the file does not match the redacted file pattern, it returns nothing.
+The example input here is only part of the full json object but these are the only fields checked. 
 
 Given the following input:
 
 ```json
-[
-  {
-    "fileId": "079bc416-180c-45cc-a943-7c6d63c21d57",
-    "originalPath": "/a/path/file.txt"
-  },
-  {
-    "fileId": "9e31f5f3-7240-4802-9442-766307fc9501",
-    "originalPath": "/a/path/file_R1.txt"
-  },
-  {
-    "fileId": "2cfc0597-53d4-4a10-aa5a-e49be49aaa9b",
-    "originalPath": "/a/path/file2_R.txt"
-  },
-  {
-    "fileId": "4ad0037f-45ae-410a-9e0f-31bece7cef85",
-    "originalPath": "/another/path/file3_R.txt"
-  },
-  {
-    "fileId": "6de7cc09-0bf2-4216-ae78-29b8f9ef6220",
-    "originalPath": "/another/path/file3.txt"
-  },
-  {
-    "fileId": "13671f42-5b15-4e55-95e9-607185b84bbd",
-    "originalPath": "/another/path/file3.doc"
-  },
-  {
-    "fileId": "f3a6f37e-c0fb-4fdd-b5a0-fe6dd31e57cb",
-    "originalPath": "/a/path/file4_R.doc"
-  },
-  {
-    "fileId": "4509ffee-69d2-48da-b771-070a4d3a376d",
-    "originalPath": "/a/path/file4_R.pdf"
-  },
-  {
-    "fileId": "8cb1078a-f990-4875-81e1-c4120fdd01f2",
-    "originalPath": "/a/path/file5.pdf"
-  }
-]
+{
+  "results": [
+    {
+      "fileId": "079bc416-180c-45cc-a943-7c6d63c21d57",
+      "originalPath": "/a/path/file.txt"
+    },
+    {
+      "fileId": "9e31f5f3-7240-4802-9442-766307fc9501",
+      "originalPath": "/a/path/file_R1.txt"
+    },
+    {
+      "fileId": "2cfc0597-53d4-4a10-aa5a-e49be49aaa9b",
+      "originalPath": "/a/path/file2_R.txt"
+    },
+    {
+      "fileId": "4ad0037f-45ae-410a-9e0f-31bece7cef85",
+      "originalPath": "/another/path/file3_R.txt"
+    },
+    {
+      "fileId": "6de7cc09-0bf2-4216-ae78-29b8f9ef6220",
+      "originalPath": "/another/path/file3.txt"
+    },
+    {
+      "fileId": "13671f42-5b15-4e55-95e9-607185b84bbd",
+      "originalPath": "/another/path/file3.doc"
+    },
+    {
+      "fileId": "f3a6f37e-c0fb-4fdd-b5a0-fe6dd31e57cb",
+      "originalPath": "/a/path/file4_R.doc"
+    },
+    {
+      "fileId": "4509ffee-69d2-48da-b771-070a4d3a376d",
+      "originalPath": "/a/path/file4_R.pdf"
+    },
+    {
+      "fileId": "8cb1078a-f990-4875-81e1-c4120fdd01f2",
+      "originalPath": "/a/path/file5.pdf"
+    }
+  ]
+}
 
 ```
 It will group the files by directory

--- a/build.sbt
+++ b/build.sbt
@@ -22,3 +22,7 @@ lazy val root = (project in file("."))
   case PathList("META-INF", xs@_*) => MergeStrategy.discard
   case _ => MergeStrategy.first
 }
+
+(Test / fork) := true
+(Test / javaOptions) += s"-Dconfig.file=${sourceDirectory.value}/test/resources/application.conf"
+(Test / envVars) := Map("AWS_ACCESS_KEY_ID" -> "test", "AWS_SECRET_ACCESS_KEY" -> "test", "S3_ENDPOINT" -> "http://localhost:9005")

--- a/build.sbt
+++ b/build.sbt
@@ -8,10 +8,17 @@ lazy val root = (project in file("."))
   .settings(
     name := "tdr-redacted-files",
     libraryDependencies ++= Seq(
+      backendCheckUtils,
       circeCore,
       circeParser,
       circeGeneric,
-      scalaTest % Test
+      scalaTest % Test,
+      wiremock % Test
     ),
     assembly / assemblyJarName := "redacted-files.jar"
   )
+
+(assembly / assemblyMergeStrategy) := {
+  case PathList("META-INF", xs@_*) => MergeStrategy.discard
+  case _ => MergeStrategy.first
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,8 +4,10 @@ import sbt._
 object Dependencies {
   private val circeVersion = "0.14.3"
 
+  lazy val backendCheckUtils = "uk.gov.nationalarchives" %% "tdr-backend-checks-utils" % "0.1.0"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.14"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.15"
+  lazy val wiremock = "com.github.tomakehurst" % "wiremock-jre8" % "2.35.0"
 }

--- a/src/main/scala/uk/gov/nationalarchives/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/LambdaRunner.scala
@@ -3,52 +3,11 @@ package uk.gov.nationalarchives
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 object LambdaRunner extends App {
-  val body =
-    """
-      |{
-      |  "results": [
-      |    {
-      |      "fileId": "20d80488-d247-47cf-8687-be26de2558b5",
-      |      "originalPath": "smallfile/subfolder/subfolder-nested/subfolder-nested-1.txt",
-      |      "consignmentId": "cedba409-c806-439f-8982-943afb03c85a",
-      |      "userId": "030cf12c-8d5d-46b9-b86a-38e0920d0e1a",
-      |      "results": [
-      |        {
-      |          "antivirus": {
-      |            "software": "yara",
-      |            "softwareVersion": "4.2.0",
-      |            "databaseVersion": "$LATEST",
-      |            "result": "",
-      |            "datetime": 1670333368632,
-      |            "fileId": "20d80488-d247-47cf-8687-be26de2558b5"
-      |          }
-      |        },
-      |        {
-      |          "fileId": "20d80488-d247-47cf-8687-be26de2558b5",
-      |          "software": "Droid",
-      |          "softwareVersion": "6.6.0-rc2",
-      |          "binarySignatureFileVersion": "109",
-      |          "containerSignatureFileVersion": "20221102",
-      |          "method": "pronom",
-      |          "matches": [
-      |            {
-      |              "extension": "txt",
-      |              "identificationBasis": "Extension",
-      |              "puid": "x-fmt/111"
-      |            }
-      |          ]
-      |        },
-      |        {
-      |          "checksum": {
-      |            "fileId": "20d80488-d247-47cf-8687-be26de2558b5",
-      |            "sha256Checksum": "87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7"
-      |          }
-      |        }
-      |      ]
-      |    }
-      |  ]
+  private val body =
+    """{
+      |  "key": "a4c0e084-7562-46dd-9724-92ac9b64d149/d5cd3fb2-4869-4d28-9537-4655486a8a2d/results.json",
+      |  "bucket": "tdr-backend-checks-intg"
       |}
-      |
       |""".stripMargin
   val baos = new ByteArrayInputStream(body.getBytes())
   val output = new ByteArrayOutputStream()


### PR DESCRIPTION
There is a size limit of 256Kb for messages passed between steps and for large consignments, the message is more than this.

To solve this, each step reads its input from S3 and once it has carried out its step, writes the new output to S3 again.

I've updated this lambda to use the backend-check-utils classes and
updated the test to work with calls to S3.
